### PR TITLE
[libqofono] Fix phonesim setup in tests. Contributes to JB#52788

### DIFF
--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -24,15 +24,8 @@ INCLUDEPATH += ../src
 OTHER_FILES += \
     plugin.json plugins.qmltypes qmldir
 
-equals(QT_MAJOR_VERSION, 4): {
-    qmldir.path = $$[QT_INSTALL_IMPORTS]/MeeGo/QOfono
-    target.path = $$[QT_INSTALL_IMPORTS]/MeeGo/QOfono
-}
-
-equals(QT_MAJOR_VERSION, 5): {
-    qmldir.path = $$[QT_INSTALL_QML]/MeeGo/QOfono
-    target.path = $$[QT_INSTALL_QML]/MeeGo/QOfono
-}
+qmldir.path = $$[QT_INSTALL_QML]/MeeGo/QOfono
+target.path = $$[QT_INSTALL_QML]/MeeGo/QOfono
 
 qmldir.files += qmldir plugins.qmltypes
 

--- a/rpm/libqofono-qt5.spec
+++ b/rpm/libqofono-qt5.spec
@@ -97,7 +97,6 @@ export QT_SELECT=5
 
 %files tests
 %defattr(-,root,root,-)
-%{_libdir}/%{name}/tests/*
 /opt/tests/%{name}/*
 
 %files examples

--- a/test/auto/tests/runtest.sh
+++ b/test/auto/tests/runtest.sh
@@ -2,4 +2,4 @@
 
 systemctl --user restart phonesim
 sleep 15
-exec "/usr/lib/libqofono-qt5/tests/${1?Test executable expected}"
+exec "/opt/tests/libqofono-qt5/${1?Test executable expected}"

--- a/test/auto/tests/testcase.pri
+++ b/test/auto/tests/testcase.pri
@@ -4,6 +4,6 @@ QOFONO_DIR = ../../../src/
 INCLUDEPATH += ../lib ../ $$QOFONO_DIR
 
 LIBS += -L$$QOFONO_DIR -lqofono-qt5
-target.path = $$[QT_INSTALL_LIBS]/libqofono-qt5/tests
+target.path = /opt/tests/libqofono-qt5
 
 INSTALLS += target

--- a/test/auto/tests/testcase.pri
+++ b/test/auto/tests/testcase.pri
@@ -3,14 +3,7 @@ QT = core testlib dbus
 QOFONO_DIR = ../../../src/
 INCLUDEPATH += ../lib ../ $$QOFONO_DIR
 
-equals(QT_MAJOR_VERSION, 4): {
-    LIBS += -L$$QOFONO_DIR -lqofono
-    target.path = $$[QT_INSTALL_LIBS]/libqofono/tests
-}
+LIBS += -L$$QOFONO_DIR -lqofono-qt5
+target.path = $$[QT_INSTALL_LIBS]/libqofono-qt5/tests
 
-equals(QT_MAJOR_VERSION, 5): {
-    LIBS += -L$$QOFONO_DIR -lqofono-qt5
-    target.path = $$[QT_INSTALL_LIBS]/libqofono-qt5/tests
-
-}
 INSTALLS += target

--- a/test/auto/tests/tests.xml
+++ b/test/auto/tests/tests.xml
@@ -5,15 +5,14 @@
       <description>Ofono test set with manual, automatic and semi-automatic case.</description>
       <pre_steps>
         <step>/usr/sbin/mcetool --set-never-blank=disabled --set-demo-mode=off --block=1 --set-never-blank=enabled --unblank-screen --block=1 --set-tklock-mode=unlocked</step>
-        <step>/usr/sbin/run-blts-root /bin/mv /var/lib/environment/ofono/noplugin.conf /var/lib/environment/ofono/noplugin.conf_LIBQOFONO_TESTS_DISABLED || true</step>
-        <step>/usr/sbin/run-blts-root /bin/sh -c "/bin/echo OFONO_ARGS=--noplugin=ril > /var/lib/environment/ofono/LIBQOFONO_TESTS_noplugin.conf" || true</step>
+        <!-- Prefixing with xxx_ to avoid adaptation configs overriding this value -->
+        <step>/usr/sbin/run-blts-root /bin/sh -c "/bin/echo OFONO_ARGS=--noplugin=ril > /var/lib/environment/ofono/xxx_LIBQOFONO_TESTS_noplugin.conf" || true</step>
         <step>/usr/sbin/run-blts-root /usr/bin/systemctl restart ofono.service</step>
         <step>/usr/sbin/run-blts-root /usr/bin/systemctl stop connman.service</step>
       </pre_steps>
       <post_steps>
         <step>/usr/bin/systemctl --user stop phonesim.service</step>
-        <step>/usr/sbin/run-blts-root /bin/rm /var/lib/environment/ofono/LIBQOFONO_TESTS_noplugin.conf || true</step>
-        <step>/usr/sbin/run-blts-root /bin/mv /var/lib/environment/ofono/noplugin.conf_LIBQOFONO_TESTS_DISABLED /var/lib/environment/ofono/noplugin.conf || true</step>
+        <step>/usr/sbin/run-blts-root /bin/rm /var/lib/environment/ofono/xxx_LIBQOFONO_TESTS_noplugin.conf || true</step>
         <step>/usr/sbin/run-blts-root /usr/bin/systemctl restart ofono.service</step>
         <step>/usr/sbin/run-blts-root /usr/bin/systemctl start connman.service</step>
         <step>/usr/sbin/mcetool --set-never-blank=disabled --set-demo-mode=off</step>

--- a/test/auto/tst_qofono/tst_qofono.pro
+++ b/test/auto/tst_qofono/tst_qofono.pro
@@ -9,7 +9,7 @@ QT -= gui
 
 LIBS += -lqofono-qt5
 TARGET = tst_qofonotest-qt5
-target.path = $$[QT_INSTALL_LIBS]/libqofono-qt5/tests
+target.path = /opt/tests/libqofono-qt5
 
 CONFIG   += console
 CONFIG   -= app_bundle


### PR DESCRIPTION
**Note that this is not yet enough to make the tests work again.**

Previously this did not override bluez configration from adaptation and
thus phonesim was not loaded. It's not necessary to rename those
configs since only the last definition of OFONO_ARGS is used.

Drop Qt4 legacy. Support 64-bits in runtest.sh.