### PR TITLE
Fix the rest of the tests

### DIFF
--- a/test/auto/tests/tests.xml
+++ b/test/auto/tests/tests.xml
@@ -35,7 +35,8 @@
       <case manual="true" name="tst_qofonocellbroadcast">
         <step>/opt/tests/libqofono-qt5/runtest.sh tst_qofonocellbroadcast</step>
       </case>
-      <case name="tst_qofonoconnmancontext">
+      <case manual="true" name="tst_qofonoconnmancontext">
+        <!-- EXPECTFAIL: Not supported by Sailfish ofono -->
         <step>/opt/tests/libqofono-qt5/runtest.sh tst_qofonoconnmancontext</step>
       </case>
       <case name="tst_qofonoconnman">

--- a/test/auto/tests/tst_qofonoconnman.cpp
+++ b/test/auto/tests/tst_qofonoconnman.cpp
@@ -44,15 +44,9 @@ private slots:
     {
         m->setRoamingAllowed(true);
         QTRY_COMPARE(m->roamingAllowed(), true);
-        Q_FOREACH (QString context, m->contexts()) {
-            m->removeContext(context);
-        }
-        QTRY_VERIFY(m->contexts().isEmpty());
 
         QSignalSpy roam(m,SIGNAL(roamingAllowedChanged(bool)));
         QSignalSpy pow(m, SIGNAL(poweredChanged(bool)));
-        QSignalSpy add(m, SIGNAL(contextAdded(QString)));
-        QSignalSpy rem(m, SIGNAL(contextRemoved(QString)));
 
         m->setPowered(false);
         QTRY_COMPARE(pow.count(), 1);
@@ -72,39 +66,19 @@ private slots:
         QCOMPARE(roam.takeFirst().at(0).toBool(), true);
         QCOMPARE(m->roamingAllowed(), true);
 
-        m->addContext(QString("internet"));
-        QTRY_COMPARE(add.count(), 1);
-
         QCOMPARE(m->powered(),true);
         QCOMPARE(m->attached(),true);
         QCOMPARE(m->suspended(),false);
         QCOMPARE(m->roamingAllowed(),true);
 
-        QString path = add.takeFirst().at(0).toString();
-        m->removeContext(path);
-        QTRY_COMPARE(rem.count(), 1);
-        QCOMPARE(rem.takeFirst().at(0).toString(), path);
+        QOfonoConnectionContext* context = new QOfonoConnectionContext(this);
+        context->setContextPath(m->contexts().first());
 
-        m->addContext(QString("internet"));
-        QTRY_COMPARE(add.count(), 1);
-        path = add.takeFirst().at(0).toString();
-        QOfonoConnectionContext* contextInternet = new QOfonoConnectionContext(this);
-        contextInternet->setContextPath(path);
-        m->addContext(QString("mms"));
-        QTRY_COMPARE(add.count(), 1);
-        path = add.takeFirst().at(0).toString();
-        QOfonoConnectionContext* contextMms = new QOfonoConnectionContext(this);
-        contextMms->setContextPath(path);
-
-        contextInternet->setActive(true);
-        contextMms->setActive(true);
-        QTRY_VERIFY(contextInternet->active() && contextMms->active());
+        context->setActive(true);
+        QTRY_VERIFY(context->active());
 
         m->deactivateAll();
-        QTRY_VERIFY(!contextInternet->active());
-        QTRY_VERIFY(!contextMms->active());
-
-        QCOMPARE(rem.count(), 0);
+        QTRY_VERIFY(!context->active());
     }
 
     void cleanupTestCase()

--- a/test/auto/tests/tst_qofonosimmanager.cpp
+++ b/test/auto/tests/tst_qofonosimmanager.cpp
@@ -83,14 +83,14 @@ private slots:
         QCOMPARE(m->subscriberNumbers()[0], QString("358501234567"));
         QTRY_VERIFY(m->serviceNumbers().count() > 0);
         QCOMPARE(m->serviceNumbers().value(".HELP DESK").toString(), QString("2601"));
-        QCOMPARE(m->pinRequired(),QOfonoSimManager::NoPin);
+        QCOMPARE(m->pinRequired(), QOfonoSimManager::NoPin);
         QCOMPARE(m->lockedPins().count(), 0);
         QTRY_COMPARE(m->cardIdentifier(), QString("8949222074451242066"));
         QTRY_VERIFY(m->preferredLanguages().count() > 0);
         QCOMPARE(m->preferredLanguages()[0], QString("de"));
         QCOMPARE(m->pinRetries().count(), 0);
-        QCOMPARE(m->fixedDialing(), false);
-        QCOMPARE(m->barredDialing(), false);
+        QVERIFY(!m->fixedDialing());
+        QVERIFY(!m->barredDialing());
 
         QStringList numbers = m->subscriberNumbers();
         QStringList newNumbers;
@@ -164,11 +164,6 @@ private slots:
         QTRY_COMPARE(preferredLanguages.count(), 1);
         QStringList languages = preferredLanguages.takeFirst().at(0).toStringList();
         QCOMPARE(languages.count(), 0);
-        QCOMPARE(pinRequired.count(), 0);
-        QCOMPARE(lockedPins.count(), 0);
-        QCOMPARE(fixedDialing.count(), 0);
-        QCOMPARE(barredDialing.count(), 0);
-
         QCOMPARE(presence.count(), 0);
         QCOMPARE(subscriberIdentity.count(), 0);
         QCOMPARE(mcc.count(), 0);
@@ -177,10 +172,18 @@ private slots:
         QCOMPARE(serviceNumbers.count(), 0);
         QCOMPARE(cardIdentifier.count(), 0);
         QCOMPARE(preferredLanguages.count(), 0);
-        QCOMPARE(pinRequired.count(), 0);
-        QCOMPARE(lockedPins.count(), 0);
-        QCOMPARE(fixedDialing.count(), 0);
-        QCOMPARE(barredDialing.count(), 0);
+
+        // Signals that fire when the modem powers down
+        QCOMPARE(pinRequired.count(), 1);
+        QCOMPARE(lockedPins.count(), 1);
+        QCOMPARE(fixedDialing.count(), 1);
+        QCOMPARE(barredDialing.count(), 1);
+
+        // Verify that the values didn't change though
+        QCOMPARE(m->pinRequired(), QOfonoSimManager::NoPin);
+        QCOMPARE(m->lockedPins().count(), 0);
+        QVERIFY(!m->fixedDialing());
+        QVERIFY(!m->barredDialing());
 
         modem.setPowered(true);
         QTRY_COMPARE(modemPowered.count(), 1);
@@ -222,10 +225,17 @@ private slots:
         QCOMPARE(serviceNumbers.count(), 0);
         QCOMPARE(cardIdentifier.count(), 0);
         QCOMPARE(preferredLanguages.count(), 0);
-        QCOMPARE(pinRequired.count(), 0);
-        QCOMPARE(lockedPins.count(), 0);
-        QCOMPARE(fixedDialing.count(), 0);
-        QCOMPARE(barredDialing.count(), 0);
+        // Expect that these didn't increase anymore
+        QCOMPARE(pinRequired.count(), 1);
+        QCOMPARE(lockedPins.count(), 1);
+        QCOMPARE(fixedDialing.count(), 1);
+        QCOMPARE(barredDialing.count(), 1);
+
+        // Verify that the values didn't change still
+        QCOMPARE(m->pinRequired(), QOfonoSimManager::NoPin);
+        QCOMPARE(m->lockedPins().count(), 0);
+        QVERIFY(!m->fixedDialing());
+        QVERIFY(!m->barredDialing());
     }
 
     void testQOfonoSimManagerPin()


### PR DESCRIPTION
Fix sim manager tests. Ofono sends some redundant signals when modem powers down. Expect those and verify the values.

Drop context manipulation parts from connman tests. [Adding or removing contexts is not supported on Sailfish.](https://github.com/sailfishos/ofono/commit/19f74e6c851b31ee13ced373fcaf7544ba49079a) Keep the parts that work.

Expect failure on context tests on Sailfish. [These are not supported on Sailfish any more.](https://github.com/sailfishos/ofono/commit/19f74e6c851b31ee13ced373fcaf7544ba49079a)