### PR TITLE
libqofono: Add support for Qt6

### DIFF
--- a/src/qofonoconnectionmanager.cpp
+++ b/src/qofonoconnectionmanager.cpp
@@ -52,13 +52,21 @@ void QOfonoConnectionManager::Private::filterContexts()
             QString f(filter);
             f.remove(' ').remove('\t');
             if (f[0] == '!') {
-                QStringList blackList = f.remove(0,1).split(',', QString::SkipEmptyParts);
+                #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
+                    QStringList blackList = f.remove(0,1).split(',', Qt::SkipEmptyParts);
+                #else
+                    QStringList blackList = f.remove(0,1).split(',', QString::SkipEmptyParts);
+                #endif
                 foreach (QString path, contextList) {
                     if (!blackList.contains(contextTypes.value(path)))
                         contexts.append(path);
                 }
             } else {
-                QStringList whiteList = f.split(',', QString::SkipEmptyParts);
+                #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
+                    QStringList whiteList = f.split(',', Qt::SkipEmptyParts);
+                #else
+                    QStringList whiteList = f.split(',', QString::SkipEmptyParts);
+                #endif
                 foreach (QString path, contextList) {
                     if (whiteList.contains(contextTypes.value(path)))
                         contexts.append(path);

--- a/src/qofonomanager.cpp
+++ b/src/qofonomanager.cpp
@@ -93,7 +93,11 @@ void QOfonoManager::Private::handleGetModemsReply(QOfonoManager *obj, ObjectPath
     for (int i = 0; i < n; i++) {
         newModems.append(reply.at(i).path.path());
     }
-    qSort(newModems);
+    #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
+        std::sort(newModems.begin(), newModems.end());
+    #else
+        qSort(newModems);
+    #endif
     available = true;
     if (modems != newModems) {
         modems = newModems;
@@ -185,7 +189,11 @@ void QOfonoManager::onModemAdded(const QDBusObjectPath &path, const QVariantMap&
     if (!d_ptr->modems.contains(pathStr)) {
         QString prevDefault = defaultModem();
         d_ptr->modems.append(pathStr);
-        qSort(d_ptr->modems);
+        #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
+            std::sort(d_ptr->modems.begin(), d_ptr->modems.end());
+        #else
+            qSort(d_ptr->modems);
+        #endif
         Q_EMIT modemAdded(pathStr);
         Q_EMIT modemsChanged(d_ptr->modems);
         QString newDefault = defaultModem();


### PR DESCRIPTION
qSort has been deprecated in Qt6.
SkipEmptyParts has been moved from QString to Qt namespace.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>