### PR TITLE
[libqofono] Enable symbol hiding. JB#10155

### DIFF
--- a/src/dbustypes.h
+++ b/src/dbustypes.h
@@ -19,6 +19,8 @@
 #include <QtDBus>
 #include <QVariant>
 
+#include "qofono_global.h"
+
 struct ObjectPathProperties
 {
     QDBusObjectPath path;
@@ -30,19 +32,19 @@ typedef QList<ObjectPathProperties> ObjectPathPropertiesList;
 Q_DECLARE_METATYPE(ObjectPathProperties)
 Q_DECLARE_METATYPE(ObjectPathPropertiesList)
 
-QDBusArgument &operator<<(QDBusArgument &, const ObjectPathProperties &);
-const QDBusArgument &operator>>(const QDBusArgument &, ObjectPathProperties &);
+QOFONOSHARED_EXPORT QDBusArgument &operator<<(QDBusArgument &, const ObjectPathProperties &);
+QOFONOSHARED_EXPORT const QDBusArgument &operator>>(const QDBusArgument &, ObjectPathProperties &);
 
 namespace QOfonoDbusTypes {
-    void registerObjectPathProperties();
+    QOFONOSHARED_EXPORT void registerObjectPathProperties();
 }
 
 // Deprecated, left in for ABI compatibility
-struct OfonoPathProps { QDBusObjectPath path; QVariantMap properties; };
+struct QOFONOSHARED_EXPORT OfonoPathProps { QDBusObjectPath path; QVariantMap properties; };
 typedef QList<OfonoPathProps> QArrayOfPathProps;
 Q_DECLARE_METATYPE(OfonoPathProps)
 Q_DECLARE_METATYPE (QArrayOfPathProps)
-QDBusArgument &operator<<(QDBusArgument &, const OfonoPathProps &);
-const QDBusArgument &operator>>(const QDBusArgument &, OfonoPathProps &);
+QOFONOSHARED_EXPORT QDBusArgument &operator<<(QDBusArgument &, const OfonoPathProps &);
+QOFONOSHARED_EXPORT const QDBusArgument &operator>>(const QDBusArgument &, OfonoPathProps &);
 
 #endif // DBUSTYPES_H

--- a/src/qofono_global.h
+++ b/src/qofono_global.h
@@ -17,12 +17,13 @@
 #define QOFONO_GLOBAL_H
 
 #include <QtCore/qglobal.h>
-#include "dbustypes.h"
 
 #if defined(QOFONO_LIBRARY)
 #  define QOFONOSHARED_EXPORT Q_DECL_EXPORT
 #else
 #  define QOFONOSHARED_EXPORT Q_DECL_IMPORT
 #endif
+
+#include "dbustypes.h"
 
 #endif // QOFONO_GLOBAL_H

--- a/src/qofonoassistedsatellitenavigation.h
+++ b/src/qofonoassistedsatellitenavigation.h
@@ -20,8 +20,10 @@
 #include <QDBusVariant>
 #include <QStringList>
 
+#include "qofono_global.h"
+
 class QOfonoAssistedSatelliteNavigationPrivate;
-class QOfonoAssistedSatelliteNavigation : public QObject
+class QOFONOSHARED_EXPORT QOfonoAssistedSatelliteNavigation : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString modemPath READ modemPath WRITE setModemPath NOTIFY modemPathChanged)

--- a/src/qofonohandsfree.h
+++ b/src/qofonohandsfree.h
@@ -20,8 +20,10 @@
 #include <QDBusVariant>
 #include <QStringList>
 
+#include "qofono_global.h"
+
 class QOfonoHandsfreePrivate;
-class QOfonoHandsfree : public QObject
+class QOFONOSHARED_EXPORT QOfonoHandsfree : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString modemPath READ modemPath WRITE setModemPath NOTIFY modemPathChanged)

--- a/src/qofonohandsfreeaudioagent.h
+++ b/src/qofonohandsfreeaudioagent.h
@@ -21,8 +21,10 @@
 #include <QDBusAbstractAdaptor>
 #include <QDBusUnixFileDescriptor>
 
+#include "qofono_global.h"
+
 class QOfonoHandsfreeAudioAgentPrivate;
-class QOfonoHandsfreeAudioAgent : public QObject
+class QOFONOSHARED_EXPORT QOfonoHandsfreeAudioAgent : public QObject
 {
     Q_OBJECT
     Q_DISABLE_COPY(QOfonoHandsfreeAudioAgent)
@@ -51,7 +53,7 @@ private Q_SLOTS:
     void Release();
 };
 
-class QOfonoHandsfreeAudioAgentAdaptor : public QDBusAbstractAdaptor
+class QOFONOSHARED_EXPORT QOfonoHandsfreeAudioAgentAdaptor : public QDBusAbstractAdaptor
 {
     Q_OBJECT
     Q_CLASSINFO ("D-Bus Interface", "org.ofono.HandsfreeAudioAgent")

--- a/src/qofonohandsfreeaudiocard.h
+++ b/src/qofonohandsfreeaudiocard.h
@@ -20,8 +20,10 @@
 #include <QDBusVariant>
 #include <QDBusPendingCallWatcher>
 
+#include "qofono_global.h"
+
 class QOfonoHandsfreeAudioCardPrivate;
-class QOfonoHandsfreeAudioCard : public QObject
+class QOFONOSHARED_EXPORT QOfonoHandsfreeAudioCard : public QObject
 {
     Q_OBJECT
     Q_ENUMS(Error)

--- a/src/qofonohandsfreeaudiomanager.h
+++ b/src/qofonohandsfreeaudiomanager.h
@@ -20,8 +20,10 @@
 #include <QDBusVariant>
 #include <QStringList>
 
+#include "qofono_global.h"
+
 class QOfonoHandsfreeAudioManagerPrivate;
-class QOfonoHandsfreeAudioManager : public QObject
+class QOFONOSHARED_EXPORT QOfonoHandsfreeAudioManager : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString modemPath READ modemPath WRITE setModemPath NOTIFY modemPathChanged)

--- a/src/qofonolocationreporting.h
+++ b/src/qofonolocationreporting.h
@@ -20,8 +20,10 @@
 #include <QDBusVariant>
 #include <QStringList>
 
+#include "qofono_global.h"
+
 class QOfonoLocationReportingPrivate;
-class QOfonoLocationReporting : public QObject
+class QOFONOSHARED_EXPORT QOfonoLocationReporting : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString modemPath READ modemPath WRITE setModemPath NOTIFY modemPathChanged)

--- a/src/qofonomodeminterface2.h
+++ b/src/qofonomodeminterface2.h
@@ -17,11 +17,12 @@
 #define QOFONOMODEMINTERFACE2_H
 
 #include "dbustypes.h"
+#include "qofono_global.h"
 
 /**
  * Modem interface without properties.
  */
-class QOfonoModemInterface2 : public QObject
+class QOFONOSHARED_EXPORT QOfonoModemInterface2 : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool valid READ isValid NOTIFY validChanged)

--- a/src/qofonopositioningrequestagent.h
+++ b/src/qofonopositioningrequestagent.h
@@ -19,7 +19,7 @@
 #include "qofono_global.h"
 
 class QOfonoPositioningRequestAgentPrivate;
-class QOfonoPositioningRequestAgent : public QObject
+class QOFONOSHARED_EXPORT QOfonoPositioningRequestAgent : public QObject
 {
     Q_OBJECT
     Q_DISABLE_COPY(QOfonoPositioningRequestAgent)

--- a/src/src.pro
+++ b/src/src.pro
@@ -308,7 +308,7 @@ headers.files = $$PUBLIC_HEADERS
 
 xmlfiles.files = $$XML_FILES
 
-CONFIG += create_pc create_prl link_pkgconfig
+CONFIG += hide_symbols create_pc create_prl link_pkgconfig
 
 QMAKE_PKGCONFIG_DESTDIR = pkgconfig
 QMAKE_PKGCONFIG_INCDIR = $$headers.path


### PR DESCRIPTION
Finish long time halfway done symbol hiding. Most of the things were exported already but the CONFIG wasn't on. Some newer classes were missing the declaration, added now to everything on public headers.

For the dbus_types.h I'm not sure should that belong to the installed headers, but since it's there exported now all the content.

@Tomin1 @llewelld @monich 