### PR TITLE
the qml.path variable must contain only directory not filename

### DIFF
--- a/ofonotest/ofonotest.pro
+++ b/ofonotest/ofonotest.pro
@@ -11,7 +11,7 @@ contains(CONFIG,no-module-prefix) {
 
 qml.files += \
     qml/ofonotest/main.qml
-qml.path = /opt/examples/libqofono-qt5/qml/ofonotest/main.qml
+qml.path = /opt/examples/libqofono-qt5/qml/ofonotest
 
 target.path = /opt/examples/libqofono-qt5/
 INSTALLS += target qml


### PR DESCRIPTION
otherwise is file installed into /opt/examples/libqofono-qt5/qml/ofonotest/main.qml/main.qml (at least with Qt 5.15.7) and example application simply doesn't work