### PR TITLE
Non-initialized .modems breaks example app

### DIFF
--- a/ofonotest/main.cpp
+++ b/ofonotest/main.cpp
@@ -1,5 +1,6 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QWindow>
 
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {

--- a/ofonotest/qml/ofonotest/main.qml
+++ b/ofonotest/qml/ofonotest/main.qml
@@ -1,74 +1,148 @@
 import QtQuick 2.0
+import QtQuick.Window 2.0
 import QOfono 0.2
 
-
-Rectangle {
+Window {
     width: 480
     height: 560
-    Text {
-        id: textLine
-        anchors.centerIn: parent
+    visible: true
+
+    Column {
+
+        anchors.fill: parent
+
+        Text {
+            text: context1.active ? "online" : "offline"
+        }
+
+//        Text {
+//            text:  "modem Manufacturer " + modemDefault.manufacturer
+//        }
+
+        Text {
+            id: textLine2
+
+            text: manager.available ? netreg.name : "Ofono not available"
+        }
+
+        Text {
+            text: "simManager.pinRequired " + simManager.pinRequired
+            visible: simManager.pinRequired !== OfonoSimManager.NoPin
+        }
+
+        Repeater {
+            model: manager.modems
+
+            Text {
+                text: modelData
+                font.bold: modelData === manager.defaultModem
+            }
+
+        }
+
     }
-    Text {
-        id: textLine2
-        anchors.top: textLine.bottom
-        text: manager.available ? netreg.name : "Ofono not available"
-    }
+
     MouseArea {
         anchors.fill: parent
         onClicked: {
-          context1.active = !context1.active
+            context1.active = !context1.active
+            console.log("context1.active " + context1.active)
         }
     }
 
     OfonoManager {
         id: manager
+
         onAvailableChanged: {
             console.log("Ofono is " + available)
-           textLine2.text = manager.available ? netreg.currentOperator["Name"].toString() :"Ofono not available"
         }
         onModemAdded: {
-            console.log("modem added "+modem)
+            console.log("modem added " + modem)
         }
-        onModemRemoved: console.log("modem removed")
+        onModemRemoved: {
+            console.log("modem removed")
+        }
+        onModemsChanged: {
+            console.log("ModemsChanged " + manager.modems)
+        }
     }
 
     OfonoConnMan {
-       id: ofono1
-       Component.onCompleted: {
-       //    console.log(manager.modems)
-       }
-       modemPath: manager.modems[0]
+        id: ofono1
+
+        modemPath: manager.defaultModem
+        onValidChanged: {
+            if (ofono1.valid) {
+                console.log("OfonoConnMan.contexts " + ofono1.contexts)
+            }
+        }
     }
 
     OfonoModem {
-        id: modem1
-       modemPath: manager.modems[0]
+        id: modemDefault
 
+        modemPath: manager.defaultModem
+
+        onValidChanged: {
+            console.log(modemDefault.modemPath + ": modemDefault.valid " + modemDefault.valid)
+            if (modemDefault.valid) {
+//                console.log("modemDefault.name " + modemDefault.name)
+//                console.log("modemDefault.model " + modemDefault.model)
+                console.log("modemDefault.manufacturer " + modemDefault.manufacturer)
+                console.log("modemDefault.features " + modemDefault.features)
+            }
+        }
+    }
+
+    OfonoSimManager {
+        id: simManager
+
+        modemPath: modemDefault.modemPath
+        onValidChanged: {
+            if (valid) {
+                console.log("manager.pinRequired " + simManager.pinRequired)
+            }
+        }
     }
 
     OfonoContextConnection {
         id: context1
-        contextPath : ofono1.contexts[0]
-        Component.onCompleted: {
-            textLine.text = context1.active ? "online" : "offline"
-      }
-        onActiveChanged: {
-            textLine.text = context1.active ? "online" : "offline"
-        }
+
+        contextPath: (ofono1.contexts !== undefined && ofono1.contexts.length > 0) ? ofono1.contexts[0] : ""
     }
+
     OfonoNetworkRegistration {
-        modemPath: manager.modems[0]
         id: netreg
+
+        modemPath: manager.defaultModem
         Component.onCompleted: {
             netreg.scan()
         }
-
-      onNetworkOperatorsChanged : {
-          console.log("operators :"+netreg.currentOperator["Name"].toString())
+        onScanFinished: {
+            if (valid) {
+                console.log("[scanFinished] netreg.networkOperators: " + netreg.networkOperators)
+            }
+        }
+        onNetworkOperatorsChanged: {
+            if (valid) {
+                console.log("[operatorsChanged] netreg.networkOperators: " + netreg.networkOperators)
+            }
+        }
+        onValidChanged: {
+            if (valid) {
+                console.log("[validChanged] netreg.networkOperators: " + netreg.networkOperators)
+            }
         }
     }
+
     OfonoNetworkOperator {
         id: netop
+
+        onValidChanged: {
+            if (valid) {
+                console.log("netop: " + name + " / " + operatorPath)
+            }
+        }
     }
+
 }


### PR DESCRIPTION
It seems there is an lazy initialization of ModemManager.modems as consequence, the modems[0] are not available at the time of start application and nothing works.

Similar OfonoConnMan contexts are not initialized. The binding must check if array is defined and its length

I have added also the SimManager check to make sure that the Pin is entered, because it prevents further testing.

I am not sure about netreg.currentOperator["Name"] I keept it as is was