### PR TITLE
[libqofono] Reiterate deprecated qt api usage. JB#59963

### DIFF
--- a/src/qofonomanager.cpp
+++ b/src/qofonomanager.cpp
@@ -93,7 +93,7 @@ void QOfonoManager::Private::handleGetModemsReply(QOfonoManager *obj, ObjectPath
     for (int i = 0; i < n; i++) {
         newModems.append(reply.at(i).path.path());
     }
-    qOfonoSort(newModems);
+    std::sort(newModems.begin(), newModems.end());
     available = true;
     if (modems != newModems) {
         modems = newModems;
@@ -185,7 +185,7 @@ void QOfonoManager::onModemAdded(const QDBusObjectPath &path, const QVariantMap&
     if (!d_ptr->modems.contains(pathStr)) {
         QString prevDefault = defaultModem();
         d_ptr->modems.append(pathStr);
-        qOfonoSort(d_ptr->modems);
+        std::sort(d_ptr->modems.begin(), d_ptr->modems.end());
         Q_EMIT modemAdded(pathStr);
         Q_EMIT modemsChanged(d_ptr->modems);
         QString newDefault = defaultModem();

--- a/src/qofonoutils_p.h
+++ b/src/qofonoutils_p.h
@@ -17,12 +17,10 @@
 
 #include "qofono_global.h"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 #  define QOfonoSkipEmptyParts Qt::SkipEmptyParts
-#  define qOfonoSort(what) std::sort((what).begin(), (what).end())
 #else
 #  define QOfonoSkipEmptyParts QString::SkipEmptyParts
-#  define qOfonoSort(what) qSort(what)
 #endif
 
 namespace qofono {


### PR DESCRIPTION
We don't need std::sort wrapped, it should work on all(?) Qt5 versions.

And SkipEmptyParts is available already before Qt6, let's adjust that and avoid potential warnings with new enough Qt5.