### PR TITLE
fix invalid xml

### DIFF
--- a/src/dbus/ofono_handsfree.xml
+++ b/src/dbus/ofono_handsfree.xml
@@ -14,7 +14,7 @@
             <arg type="s"/>
             <arg type="v"/>
         </signal>
-        <method name="RequestPhoneNumber"/>
+        <method name="RequestPhoneNumber">
 			<arg type="s" direction="out"/>
 		</method>
 	</interface>

--- a/src/dbus/ofono_location_reporting.xml
+++ b/src/dbus/ofono_location_reporting.xml
@@ -10,7 +10,6 @@
                         <arg type="h" direction="out"/>
                 </method>
                 <method name="Release" />
-                </method>
         </interface>
 
 </node>

--- a/src/dbus/ofono_positioning_request_agent.xml
+++ b/src/dbus/ofono_positioning_request_agent.xml
@@ -8,7 +8,6 @@
                 <method name="ResetAssistanceData">
                 </method>
                 <method name="Release" />
-                </method>
         </interface>
 
 </node>


### PR DESCRIPTION
The qdbusxml2cpp complains that xml is incorrect. It leads to compilation error in my environment

```
/usr/lib/qt6/bin/qdbusxml2cpp -N -c OfonoHandsfree -p ofono_handsfree_interface.h: ../../src/dbus/ofono_handsfree.xml
../../src/dbus/ofono_handsfree.xml:18:5: warning: Unknown element 'arg' while parsing interface
../../src/dbus/ofono_handsfree.xml:19:4: error: Invalid Interface specification
../../src/dbus/ofono_handsfree.xml:19:4: error: XML error: Opening and ending tag mismatch.
```