### PR TITLE
[libqofono] Refactor to use Q_SLOTS macro in header files. JB#62567

### DIFF
--- a/src/qofonoassistedsatellitenavigation.h
+++ b/src/qofonoassistedsatellitenavigation.h
@@ -40,7 +40,7 @@ public:
 Q_SIGNALS:
     void modemPathChanged(const QString &path);
 
-public slots:
+public Q_SLOTS:
 
     void registerPositioningRequestAgent(const QString &path);
     void sendPositioningElement(const QString &xmlElement);

--- a/src/qofonocallbarring.h
+++ b/src/qofonocallbarring.h
@@ -60,13 +60,13 @@ Q_SIGNALS:
     void disableAllIncomingComplete(bool success);
     void disableAllOutgoingComplete(bool success);
 
-public slots:
+public Q_SLOTS:
     void changePassword(const QString &oldPassword, const QString &newPassword);
     void disableAll(const QString &password);
     void disableAllIncoming(const QString &password);
     void disableAllOutgoing(const QString &password);
 
-private slots:
+private Q_SLOTS:
     void setVoiceIncomingComplete(QDBusPendingCallWatcher *);
     void setVoiceOutgoingComplete(QDBusPendingCallWatcher *);
     void changePasswordCallComplete(QDBusPendingCallWatcher *);

--- a/src/qofonocallmeter.h
+++ b/src/qofonocallmeter.h
@@ -75,7 +75,7 @@ Q_SIGNALS:
 private:
     static Error errorNameToEnum(const QString &errorName);
 
-private slots:
+private Q_SLOTS:
     void onResetFinished(QDBusPendingCallWatcher *call);
 
 protected:

--- a/src/qofonoconnectionmanager.h
+++ b/src/qofonoconnectionmanager.h
@@ -74,13 +74,13 @@ Q_SIGNALS:
     void contextsChanged(const QStringList &contexts);
     void filterChanged(const QString &filter);
 
-public slots:
+public Q_SLOTS:
     void deactivateAll();
     void addContext(const QString &type);
     void removeContext(const QString &path);
     void resetContexts(); // Since 0.110
 
-private slots:
+private Q_SLOTS:
     void onAddContextFinished(QDBusPendingCallWatcher *watch);
     void onRemoveContextFinished(QDBusPendingCallWatcher *watch);
     void onDeactivateAllFinished(QDBusPendingCallWatcher *watch);

--- a/src/qofonohandsfree.h
+++ b/src/qofonohandsfree.h
@@ -58,7 +58,7 @@ Q_SIGNALS:
 private:
     QOfonoHandsfreePrivate *d_ptr;
 
-private slots:
+private Q_SLOTS:
     void propertyChanged(const QString &property,const QDBusVariant &value);
 };
 

--- a/src/qofonohandsfreeaudioagent.h
+++ b/src/qofonohandsfreeaudioagent.h
@@ -42,7 +42,7 @@ Q_SIGNALS:
     void newConnection(const QString &card, QDBusUnixFileDescriptor sco, const QByteArray &codec);
     void release();
 
-public slots:
+public Q_SLOTS:
     
 private:
     QOfonoHandsfreeAudioAgentPrivate *d_ptr;

--- a/src/qofonohandsfreeaudiocard.h
+++ b/src/qofonohandsfreeaudiocard.h
@@ -55,14 +55,14 @@ Q_SIGNALS:
     void modemPathChanged(const QString &path);
     void connectAudioComplete(QOfonoHandsfreeAudioCard::Error error, const QString &errorString);
 
-public slots:
+public Q_SLOTS:
     void connectAudio();
 
 private:
     QOfonoHandsfreeAudioCardPrivate *d_ptr;
     Error errorNameToEnum(const QString &errorName);
 
-private slots:
+private Q_SLOTS:
     void propertyChanged(const QString &property,const QDBusVariant &value);
     void connectAudioFinished(QDBusPendingCallWatcher *call);
 };

--- a/src/qofonohandsfreeaudiomanager.h
+++ b/src/qofonohandsfreeaudiomanager.h
@@ -51,7 +51,7 @@ Q_SIGNALS:
 
     void modemPathChanged(const QString &path);
 
-public slots:
+public Q_SLOTS:
     QStringList cards() const;
     void registerAgent(const QString &path, CodecTypeFlags codecs);
 

--- a/src/qofonolocationreporting.h
+++ b/src/qofonolocationreporting.h
@@ -41,7 +41,7 @@ public:
     bool enabled() const;
 
     bool isValid() const;
-public slots:
+public Q_SLOTS:
     void release();
     int request();
 Q_SIGNALS:
@@ -50,7 +50,7 @@ Q_SIGNALS:
 private:
     QOfonoLocationReportingPrivate *d_ptr;
 
-private slots:
+private Q_SLOTS:
 };
 
 #endif // QOFONOQLOCATIONREPORTING_H

--- a/src/qofonomessagemanager.h
+++ b/src/qofonomessagemanager.h
@@ -76,7 +76,7 @@ Q_SIGNALS:
     void setBearerComplete(bool success);
     void setAlphabetComplete(bool success);
 
-private slots:
+private Q_SLOTS:
     void onMessageAdded(const QDBusObjectPath &path, const QVariantMap &properties);
     void onMessageRemoved(const QDBusObjectPath &path);
     void onGetMessagesFinished(QDBusPendingCallWatcher *watch);

--- a/src/qofonomodeminterface2.h
+++ b/src/qofonomodeminterface2.h
@@ -55,7 +55,7 @@ protected:
     virtual void dbusInterfaceDropped();
     QDBusAbstractInterface *dbusInterface() const;
 
-private slots:
+private Q_SLOTS:
     void onModemInterfacesChanged(const QStringList &interfaces);
 
 private:

--- a/src/qofononetworkoperator.h
+++ b/src/qofononetworkoperator.h
@@ -82,7 +82,7 @@ Q_SIGNALS:
 private:
     static Error errorNameToEnum(const QString &errorName);
 
-private slots:
+private Q_SLOTS:
     void onRegisterFinished(QDBusPendingCallWatcher *call);
 
 protected:

--- a/src/qofononetworkregistration.h
+++ b/src/qofononetworkregistration.h
@@ -96,7 +96,7 @@ Q_SIGNALS:
     void registrationFinished();
     void registrationError(const QString &errorMessage);
 
-private slots:
+private Q_SLOTS:
     void onOperatorsChanged(const ObjectPathPropertiesList &operators);
     void onOperatorStatusChanged(const QString &status);
     void onScanFinished(QDBusPendingCallWatcher *watch);

--- a/src/qofonoobject.h
+++ b/src/qofonoobject.h
@@ -91,7 +91,7 @@ protected:
     void resetDbusInterface(const QVariantMap *properties = Q_NULLPTR);
     void fixObjectPath(const QString &path);
 
-private slots:
+private Q_SLOTS:
     void onGetPropertiesFinished(QDBusPendingCallWatcher *watch);
     void onSetPropertyFinished(QDBusPendingCallWatcher *watch);
     void onPropertyChanged(const QString &key, const QDBusVariant &value);

--- a/src/qofonophonebook.h
+++ b/src/qofonophonebook.h
@@ -44,10 +44,10 @@ Q_SIGNALS:
     void importFailed();
     void importingChanged();
 
-public slots:
+public Q_SLOTS:
     void beginImport();
 
-private slots:
+private Q_SLOTS:
     void onImportFinished(QDBusPendingCallWatcher *watch);
 
 protected:

--- a/src/qofonosimmanager.h
+++ b/src/qofonosimmanager.h
@@ -119,7 +119,7 @@ Q_SIGNALS:
     void lockPinComplete(QOfonoSimManager::Error error, const QString &errorString);
     void unlockPinComplete(QOfonoSimManager::Error error, const QString &errorString);
 
-public slots:
+public Q_SLOTS:
     void changePin(QOfonoSimManager::PinType pinType, const QString &oldpin, const QString &newpin);
     void enterPin(QOfonoSimManager::PinType pinType, const QString &pin);
     void resetPin(QOfonoSimManager::PinType pinType, const QString &puk, const QString &newpin);
@@ -144,7 +144,7 @@ protected:
     QVariant convertProperty(const QString &property, const QVariant &value);
     void propertyChanged(const QString &property, const QVariant &value);
 
-private slots:
+private Q_SLOTS:
     void changePinCallFinished(QDBusPendingCallWatcher *call);
     void enterPinCallFinished(QDBusPendingCallWatcher *call);
     void resetPinCallFinished(QDBusPendingCallWatcher *call);

--- a/src/qofonosupplementaryservices.h
+++ b/src/qofonosupplementaryservices.h
@@ -66,7 +66,7 @@ protected:
     QDBusAbstractInterface *createDbusInterface(const QString &path);
     void propertyChanged(const QString &key, const QVariant &value);
 
-private slots:
+private Q_SLOTS:
     void initiateResponseReceived(QDBusPendingCallWatcher*);
     void respondResponseReceived(QDBusPendingCallWatcher*);
     void cancelResponseReceived(QDBusPendingCallWatcher*);

--- a/src/qofonovoicecall.h
+++ b/src/qofonovoicecall.h
@@ -91,7 +91,7 @@ Q_SIGNALS:
     void hangupComplete(QOfonoVoiceCall::Error error, const QString &errorString);
     void deflectComplete(QOfonoVoiceCall::Error error, const QString &errorString);
 
-public slots:
+public Q_SLOTS:
     void answer();
     void hangup();
     void deflect(const QString &number);
@@ -99,7 +99,7 @@ public slots:
 private:
     static Error errorNameToEnum(const QString &errorName);
 
-private slots:
+private Q_SLOTS:
     void onDbusCallFinished(QDBusPendingCallWatcher *watch);
 
 protected:

--- a/src/qofonovoicecallmanager.h
+++ b/src/qofonovoicecallmanager.h
@@ -65,7 +65,7 @@ Q_SIGNALS:
     void barringActive(const QString &type);
     void forwarded(const QString &type);
 
-public slots:
+public Q_SLOTS:
     void dial(const QString &number, const QString &calleridHide);
     void hangupAll();
     void sendTones(const QString &tonestring);
@@ -77,7 +77,7 @@ public slots:
     void createMultiparty();
     void hangupMultiparty();
 
-private slots:
+private Q_SLOTS:
     void onGetCallsFinished(QDBusPendingCallWatcher *watch);
     void onVoidCallFinished(QDBusPendingCallWatcher *watch);
     void onObjectPathListCallFinished(QDBusPendingCallWatcher *watch);


### PR DESCRIPTION
Needed to use the library in a project with QT_NO_KEYWORDS defined and seems to be in line with the current usage of Q_SIGNALS macro.