### PR TITLE
[tests] Provide more time before failing isValid() in multipartycall test

### DIFF
--- a/test/auto/tests/tst_qofonomultipartycall.cpp
+++ b/test/auto/tests/tst_qofonomultipartycall.cpp
@@ -42,7 +42,7 @@ private slots:
         m = new QOfonoVoiceCallManager(this);
         m->setModemPath("/phonesim");
 
-        QCOMPARE(m->isValid(), true);
+        QTRY_COMPARE(m->isValid(), true);
     }
 
     void testOfonoMultipartyCalls()


### PR DESCRIPTION
When a new QOfonoVoiceCallManager object is created, it takes about 20ms (at least that's what dbus-monitor shows) between setting the modem and getting org.ofono.VCM's GetProperties() result. Immediately calling isValid() fails before then; use QTRY_COMPARE() to allow up to 5s before failing.