### PR TITLE
[tests] Fix tst_qofonosimmanager.cpp's Retries check

### DIFF
--- a/test/auto/tests/tst_qofonosimmanager.cpp
+++ b/test/auto/tests/tst_qofonosimmanager.cpp
@@ -88,7 +88,7 @@ private slots:
         QTRY_COMPARE(m->cardIdentifier(), QString("8949222074451242066"));
         QTRY_VERIFY(m->preferredLanguages().count() > 0);
         QCOMPARE(m->preferredLanguages()[0], QString("de"));
-        QCOMPARE(m->pinRetries().count(), 0);
+        QCOMPARE(m->pinRetries().count(), 1);
         QVERIFY(!m->fixedDialing());
         QVERIFY(!m->barredDialing());
 


### PR DESCRIPTION
The latest version of phonesim, on initialization, has the following for SimManager's Retries property:

task-0:          string "Retries"
task-0:          variant             array [
task-0:                dict entry(
task-0:                   string "pin"
task-0:                   byte 3
task-0:                )
task-0:             ]

So pinRetries() should expect a single entry, rather than zero.